### PR TITLE
Fixes infinite overflow threshold value.

### DIFF
--- a/Component/Classes/BMARangeSlider.m
+++ b/Component/Classes/BMARangeSlider.m
@@ -383,6 +383,10 @@ typedef NS_ENUM(NSUInteger, BMARangeSliderHandler) {
 - (CGFloat)overflowThresholdValue {
     CGFloat thresholdValue = self.maximumValue + [self overflowDistance] * (self.maximumValue - self.minimumValue) / [self rangeWidth];
 
+    if (!isfinite(thresholdValue)) {
+        thresholdValue = self.maximumValue;
+    }
+    
     return thresholdValue;
 }
 


### PR DESCRIPTION
When [self rangeWidth] returns 0, thresholdValue becomes Inf+. I was not able to specify 1000+ value for the slider as default current value.
